### PR TITLE
Fix scoop not using proxy for git commands

### DIFF
--- a/lib/git.ps1
+++ b/lib/git.ps1
@@ -1,0 +1,25 @@
+function git_proxy_cmd {
+    $proxy = $(scoop config proxy)
+    $cmd = "SET HTTPS_PROXY=$proxy&&SET HTTP_PROXY=$proxy&&git $($args |% { "$_ " })"
+    cmd /c $cmd
+}
+
+function git_clone {
+    git_proxy_cmd clone $args
+}
+
+function git_ls_remote {
+    git_proxy_cmd ls-remote $args
+}
+
+function git_pull {
+    git_proxy_cmd pull $args
+}
+
+function git_fetch {
+    git_proxy_cmd fetch $args
+}
+
+function git_log {
+    git_proxy_cmd log $args
+}

--- a/libexec/scoop-bucket.ps1
+++ b/libexec/scoop-bucket.ps1
@@ -19,6 +19,7 @@ param($cmd, $name, $repo)
 . "$psscriptroot\..\lib\core.ps1"
 . "$psscriptroot\..\lib\buckets.ps1"
 . "$psscriptroot\..\lib\help.ps1"
+. "$psscriptroot\..\lib\git.ps1"
 
 reset_aliases
 
@@ -43,15 +44,18 @@ function add_bucket($name, $repo) {
     }
 
     write-host 'checking repo...' -nonewline
-    git ls-remote $repo 2>&1 > $null
+    $out = git_ls_remote $repo 2>&1
     if($lastexitcode -ne 0) {
-        abort "'$repo' doesn't look like a valid git repository"
+        abort "'$repo' doesn't look like a valid git repository
+
+error given:
+$out"
     }
     write-host 'ok'
 
     ensure $bucketsdir > $null
     $dir = ensure $dir
-    git clone "$repo" "$dir"
+    git_clone "$repo" "$dir"
     success "$name bucket was added successfully"
 }
 

--- a/libexec/scoop-status.ps1
+++ b/libexec/scoop-status.ps1
@@ -7,6 +7,7 @@
 . "$psscriptroot\..\lib\versions.ps1"
 . "$psscriptroot\..\lib\depends.ps1"
 . "$psscriptroot\..\lib\config.ps1"
+. "$psscriptroot\..\lib\git.ps1"
 
 reset_aliases
 
@@ -16,7 +17,7 @@ $needs_update = $false
 
 if(test-path "$currentdir\.git") {
     pushd $currentdir
-    git fetch -q origin
+    git_fetch -q origin
     $commits = $(git log "HEAD..origin/$(scoop config SCOOP_BRANCH)" --oneline)
     if($commits) { $needs_update = $true }
     popd

--- a/libexec/scoop-update.ps1
+++ b/libexec/scoop-update.ps1
@@ -19,6 +19,7 @@
 . "$psscriptroot\..\lib\getopt.ps1"
 . "$psscriptroot\..\lib\depends.ps1"
 . "$psscriptroot\..\lib\config.ps1"
+. "$psscriptroot\..\lib\git.ps1"
 
 reset_aliases
 
@@ -54,11 +55,11 @@ function update_scoop() {
         rm -r -force $currentdir -ea stop
 
         # get git scoop
-        git clone -q $repo --branch $branch --single-branch $currentdir
+        git_clone -q $repo --branch $branch --single-branch $currentdir
     }
     else {
         pushd $currentdir
-        git pull -q
+        git_pull -q
         popd
     }
 
@@ -68,7 +69,7 @@ function update_scoop() {
     @(buckets) | % {
         "updating $_ bucket..."
         pushd (bucketdir $_)
-        git pull -q
+        git_pull -q
         popd
     }
     success 'scoop was updated successfully!'


### PR DESCRIPTION
Commands that call git from scoop will now pass proxy details. The
command is executed using `cmd` to avoid polluting the user's
environment as the variables set will die with the process.

Fixes #842