### PR TITLE
Replace short function names with aliases

### DIFF
--- a/lib/commands.ps1
+++ b/lib/commands.ps1
@@ -4,9 +4,10 @@ function command_files {
         | where { $_.name -match 'scoop-.*?\.ps1$' }
 }
 
-function commands {
+function scoop_commands {
 	command_files | % { command_name $_ }
 }
+set-alias commands scoop_commands
 
 function command_name($filename) {
 	$filename.name | sls 'scoop-(.*?)\.ps1$' | % { $_.matches[0].groups[1].value }
@@ -27,8 +28,9 @@ function command_path($cmd) {
     $cmd_path
 }
 
-function exec($cmd, $arguments) {
+function command_exec($cmd, $arguments) {
     $cmd_path = command_path $cmd
 
 	& $cmd_path @arguments
 }
+set-alias exec command_exec

--- a/lib/config.ps1
+++ b/lib/config.ps1
@@ -1,12 +1,13 @@
 $cfgpath = "~/.scoop"
 
-function hashtable($obj) {
+function scoop_hashtable($obj) {
 	$h = @{ }
 	$obj.psobject.properties | % {
 		$h[$_.name] = hashtable_val $_.value		
 	}
 	return $h
 }
+set-alias hashtable scoop_hashtable
 
 function hashtable_val($obj) {
 	if($obj -eq $null) { return $null }

--- a/lib/depends.ps1
+++ b/lib/depends.ps1
@@ -11,13 +11,14 @@ function install_order($apps, $arch) {
 }
 
 # http://www.electricmonk.nl/docs/dependency_resolving_algorithm/dependency_resolving_algorithm.html
-function deps($app, $arch) {
+function resolve_deps($app, $arch) {
 	$resolved = new-object collections.arraylist
 	dep_resolve $app $arch $resolved @()
 
 	if($resolved.count -eq 1) { return @() } # no dependencies
 	return $resolved[0..($resolved.count - 2)]
 }
+set-alias deps resolve_deps
 
 function dep_resolve($app, $arch, $resolved, $unresolved) {
 	$unresolved += $app

--- a/lib/getopt.ps1
+++ b/lib/getopt.ps1
@@ -8,7 +8,7 @@
 #    array of strings that are long-form options. options that take
 #    a parameter should end with '='
 # returns @(opts hash, remaining_args array, error string)
-function getopt($argv, $shortopts, $longopts) {
+function scoop_getopt($argv, $shortopts, $longopts) {
 	$opts = @{}; $rem = @()
 
 	function err($msg) {
@@ -67,3 +67,4 @@ function getopt($argv, $shortopts, $longopts) {
 
 	$opts, $rem
 }
+set-alias getopt scoop_getopt

--- a/lib/help.ps1
+++ b/lib/help.ps1
@@ -1,15 +1,18 @@
-function usage($text) {
+function help_usage($text) {
 	$text | sls '(?m)^# Usage: ([^\n]*)$' | % { "usage: " + $_.matches[0].groups[1].value }
 }
+set-alias usage help_usage
 
-function summary($text) {
+function help_summary($text) {
 	$text | sls '(?m)^# Summary: ([^\n]*)$' | % { $_.matches[0].groups[1].value }
 }
+set-alias summary help_summary
 
-function help($text) {
+function help_helptext($text) {
 	$help_lines = $text | sls '(?ms)^# Help:(.(?!^[^#]))*' | % { $_.matches[0].value; }
 	$help_lines -replace '(?ms)^#\s?(Help: )?', ''
 }
+set-alias help help_helptext
 
 function my_usage { # gets usage for the calling script
 	usage (gc $myInvocation.PSCommandPath -raw)

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -65,7 +65,7 @@ function appname_from_url($url) {
 	(split-path $url -leaf) -replace '.json$', ''
 }
 
-function locate($app) {
+function locate_app($app) {
 	$manifest, $bucket, $url = $null, $null, $null
 
 	# check if app is a url
@@ -91,6 +91,7 @@ function locate($app) {
 
 	return $app, $manifest, $bucket, $url
 }
+set-alias locate locate_app
 
 function dl_with_cache($app, $version, $url, $to, $cookies, $use_cache = $true) {
 	$cached = fullpath (cache_path $app $version $url)
@@ -319,12 +320,13 @@ function cmd_available($cmd) {
 }
 
 # for dealing with installers
-function args($config, $dir) {
+function scoop_args($config, $dir) {
 	if($config) { return $config | % { (format $_ @{'dir'=$dir}) } }
 	@()
 }
+set-alias args scoop_args
 
-function run($exe, $arg, $msg, $continue_exit_codes) {
+function scoop_run($exe, $arg, $msg, $continue_exit_codes) {
 	if($msg) { write-host $msg -nonewline }
 	try {
 		$proc = start-process $exe -wait -ea stop -passthru -arg $arg
@@ -342,6 +344,7 @@ function run($exe, $arg, $msg, $continue_exit_codes) {
 	if($msg) { write-host "done" }
 	return $true
 }
+set-alias run scoop_run
 
 function unpack_inno($fname, $manifest, $dir) {
 	if(!$manifest.innosetup) { return }
@@ -636,13 +639,14 @@ function prune_installed($apps) {
 }
 
 # check whether the app failed to install
-function failed($app, $global) {
+function install_failed($app, $global) {
 	$ver = current_version $app $global
 	if(!$ver) { return $false }
 	$info = install_info $app $ver $global
 	if(!$info) { return $true }
 	return $false
 }
+set-alias failed install_failed
 
 function ensure_none_failed($apps, $global) {
 	foreach($app in $apps) {

--- a/lib/manifest.ps1
+++ b/lib/manifest.ps1
@@ -61,10 +61,15 @@ function arch_specific($prop, $manifest, $architecture) {
 	if($manifest.$prop) { return $manifest.$prop }
 }
 
-function url($manifest, $arch) { arch_specific 'url' $manifest $arch }
-function installer($manifest, $arch) { arch_specific 'installer' $manifest $arch }
-function uninstaller($manifest, $arch) { arch_specific 'uninstaller' $manifest $arch }
-function msi($manifest, $arch) { arch_specific 'msi' $manifest $arch }
-function hash($manifest, $arch) { arch_specific 'hash' $manifest $arch }
+function manifest_url($manifest, $arch) { arch_specific 'url' $manifest $arch }
+set-alias url manifest_url
+function manifest_installer($manifest, $arch) { arch_specific 'installer' $manifest $arch }
+set-alias installer manifest_installer
+function manifest_uninstaller($manifest, $arch) { arch_specific 'uninstaller' $manifest $arch }
+set-alias uninstaller manifest_uninstaller
+function manifest_msi($manifest, $arch) { arch_specific 'msi' $manifest $arch }
+set-alias msi manifest_msi
+function manifest_hash($manifest, $arch) { arch_specific 'hash' $manifest $arch }
+set-alias hash manifest_hash
 function extract_dir($manifest, $arch) { arch_specific 'extract_dir' $manifest $arch}
 function extract_to($manifest, $arch) { arch_specific 'extract_to' $manifest $arch}

--- a/lib/versions.ps1
+++ b/lib/versions.ps1
@@ -5,19 +5,21 @@ function latest_version($app, $bucket, $url) {
 function current_version($app, $global) {
 	@(versions $app $global)[-1]
 }
-function versions($app, $global) {
+function app_versions($app, $global) {
 	$appdir = appdir $app $global
 	if(!(test-path $appdir)) { return @() }
 
 	sort_versions (gci $appdir -dir | % { $_.name })
 }
+set-alias versions app_versions
 
-function version($ver) {
+function version_string($ver) {
 	$ver.split('.') | % {
 		$num = $_ -as [int]
 		if($num) { $num } else { $_ }
 	}
 }
+set-alias version version_string
 function compare_versions($a, $b) {
 	$ver_a = @(version $a)
 	$ver_b = @(version $b)
@@ -37,7 +39,7 @@ function compare_versions($a, $b) {
 	return 0
 }
 
-function qsort($ary, $fn) {
+function scoop_qsort($ary, $fn) {
 	if($ary -eq $null) { return @() }
 	if(!($ary -is [array])) { return @($ary) }
 
@@ -50,4 +52,6 @@ function qsort($ary, $fn) {
 
 	return @() + $lesser + @($pivot) + $greater
 }
+set-alias qsort scoop_qsort
+
 function sort_versions($versions) {	qsort $versions compare_versions }

--- a/libexec/scoop-cache.ps1
+++ b/libexec/scoop-cache.ps1
@@ -11,13 +11,14 @@ param($cmd, $app)
 
 . "$psscriptroot\..\lib\help.ps1"
 
-function cacheinfo($file) {
+function scoop_cacheinfo($file) {
 	$app, $version, $url = $file.name -split '#'
 	$size = filesize $file.length
 	return new-object psobject -prop @{ app=$app; version=$version; url=$url; size=$size }
 }
+set-alias cacheinfo scoop_cacheinfo
 
-function filesize($length) {
+function cache_filesize($length) {
 	$gb = [math]::pow(2, 30)
 	$mb = [math]::pow(2, 20)
 	$kb = [math]::pow(2, 10)
@@ -32,6 +33,7 @@ function filesize($length) {
 		"$($length) B"
 	}
 }
+set-alias filesize cache_filesize
 
 switch($cmd) {
 	'rm' {

--- a/libexec/scoop-update.ps1
+++ b/libexec/scoop-update.ps1
@@ -70,7 +70,7 @@ function update_scoop() {
 	success 'scoop was updated successfully!'
 }
 
-function update($app, $global) {
+function cmd_update($app, $global) {
 	$old_version = current_version $app $global
 	$old_manifest = installed_manifest $app $old_version $global
 	$install = install_info $app $old_version $global
@@ -133,6 +133,7 @@ function update($app, $global) {
 
 	show_notes $manifest
 }
+set-alias update cmd_update
 
 function ensure_all_installed($apps, $global) {
 	$app = $apps | ? { !(installed $_ $global) } | select -first 1 # just get the first one that's not installed
@@ -149,9 +150,10 @@ function ensure_all_installed($apps, $global) {
 }
 
 # convert list of apps to list of ($app, $global) tuples
-function applist($apps, $global) {
+function scoop_applist($apps, $global) {
 	return ,@($apps |% { ,@($_, $global) })
 }
+set-alias applist scoop_applist
 
 if(!$apps) {
 	if($global) {


### PR DESCRIPTION
All one word function names have been renamed to avoid clashes
with aliases. Those functions are then aliased to their original
name.

Fixes #351